### PR TITLE
Add order editing feature

### DIFF
--- a/cli latest version/Order.java
+++ b/cli latest version/Order.java
@@ -24,6 +24,26 @@ public class Order {
         total += item.getMenuItem().getPrice() * item.getQuantity();
     }
 
+    public void updateItemQuantity(int index, int quantity) {
+        if (index < 0 || index >= orderItems.size()) return;
+        OrderItem current = orderItems.get(index);
+        orderItems.set(index, new OrderItem(current.getMenuItem(), quantity, current.getSideOrders()));
+        recalculateTotal();
+    }
+
+    public void removeItem(int index) {
+        if (index < 0 || index >= orderItems.size()) return;
+        orderItems.remove(index);
+        recalculateTotal();
+    }
+
+    private void recalculateTotal() {
+        total = 0;
+        for (OrderItem i : orderItems) {
+            total += i.getMenuItem().getPrice() * i.getQuantity();
+        }
+    }
+
     public void saveReceiptToFile() {
         try (FileWriter writer = new FileWriter("receipt_order_" + orderID + ".txt")) {
             writer.write("Receipt - Order ID: " + orderID + "\nDate: " + date + "\nCustomer: " + customerInfo.getCustomerName() + "\n\nItems:\n");

--- a/cli latest version/OrderEditor.java
+++ b/cli latest version/OrderEditor.java
@@ -1,0 +1,55 @@
+import java.util.List;
+import java.util.Scanner;
+
+public class OrderEditor {
+    public static void editOrder(Order order, Scanner scanner) {
+        while (true) {
+            List<OrderItem> items = order.getOrderItems();
+            if (items.isEmpty()) {
+                System.out.println("No items in order.");
+                return;
+            }
+
+            System.out.println("\n--- Edit Order ---");
+            for (int i = 0; i < items.size(); i++) {
+                OrderItem item = items.get(i);
+                System.out.printf("%d. %s x%d\n", i + 1, item.getMenuItem().getName(), item.getQuantity());
+            }
+            System.out.println("0. Finish Editing");
+            System.out.print("Select item number to edit/remove: ");
+            int choice;
+            try {
+                choice = Integer.parseInt(scanner.nextLine());
+            } catch (NumberFormatException e) {
+                System.out.println("Invalid input.");
+                continue;
+            }
+
+            if (choice == 0) break;
+            if (choice < 1 || choice > items.size()) {
+                System.out.println("Invalid item number.");
+                continue;
+            }
+
+            OrderItem current = items.get(choice - 1);
+            System.out.printf("Selected %s x%d\n", current.getMenuItem().getName(), current.getQuantity());
+            System.out.print("Enter new quantity (0 to remove): ");
+            int qty;
+            try {
+                qty = Integer.parseInt(scanner.nextLine());
+            } catch (NumberFormatException e) {
+                System.out.println("Invalid quantity.");
+                continue;
+            }
+
+            if (qty == 0) {
+                order.removeItem(choice - 1);
+                System.out.println("Item removed.");
+            } else {
+                order.updateItemQuantity(choice - 1, qty);
+                System.out.println("Quantity updated.");
+            }
+        }
+        System.out.println("Subtotal: RM " + (order.getTotal() / 100.0));
+    }
+}

--- a/cli latest version/POSMain.java
+++ b/cli latest version/POSMain.java
@@ -21,6 +21,11 @@ public class POSMain {
             Order currentOrder = createNewOrder();
             addItemsToOrder(menu, currentOrder);
 
+            System.out.print("Edit order items? (y/n): ");
+            if (scanner.nextLine().equalsIgnoreCase("y")) {
+                OrderEditor.editOrder(currentOrder, scanner);
+            }
+
             System.out.print("Enter payment method (e.g., Cash, Card): ");
             currentOrder.setPaymentMethod(scanner.nextLine());
 


### PR DESCRIPTION
## Summary
- add an `OrderEditor` helper for modifying orders
- support updating and removing items in `Order`
- allow editing an order in the CLI app before payment

## Testing
- `javac *.java` in `cli latest version`

------
https://chatgpt.com/codex/tasks/task_b_684bb0bdbd0c832db6fab584796101ee