### PR TITLE
Add menu persistence with text storage

### DIFF
--- a/cli latest version/MenuStorage.java
+++ b/cli latest version/MenuStorage.java
@@ -1,0 +1,49 @@
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+public class MenuStorage {
+    public static void loadMenuFromFile(Menu menu, String filePath) {
+        Path path = Path.of(filePath);
+        if (!Files.exists(path)) {
+            for (MenuItem item : MenuInitializer.getAllMenuItems()) {
+                menu.addItem(item);
+            }
+            saveMenuToFile(menu, filePath);
+            return;
+        }
+        try (BufferedReader reader = Files.newBufferedReader(path)) {
+            String line;
+            while ((line = reader.readLine()) != null) {
+                String[] parts = line.split("\\|", -1);
+                if (parts.length < 4) continue;
+                MenuItem item = new MenuItem();
+                item.setName(parts[0]);
+                try {
+                    item.setPrice(Integer.parseInt(parts[1]));
+                } catch (NumberFormatException e) {
+                    item.setPrice(0);
+                }
+                item.setDescription(parts[2]);
+                item.setImagePath(parts[3]);
+                menu.addItem(item);
+            }
+        } catch (IOException e) {
+            System.out.println("Error loading menu: " + e.getMessage());
+        }
+    }
+
+    public static void saveMenuToFile(Menu menu, String filePath) {
+        Path path = Path.of(filePath);
+        try (BufferedWriter writer = Files.newBufferedWriter(path)) {
+            for (MenuItem item : menu.getItems()) {
+                writer.write(item.getName() + "|" + item.getPrice() + "|" + item.getDescription() + "|" + item.getImagePath());
+                writer.newLine();
+            }
+        } catch (IOException e) {
+            System.out.println("Error saving menu: " + e.getMessage());
+        }
+    }
+}

--- a/cli latest version/POSMain.java
+++ b/cli latest version/POSMain.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Scanner;
 
+
 public class POSMain {
     private static Scanner scanner = new Scanner(System.in);
     private static int orderIDCounter = 1001;
@@ -11,9 +12,7 @@ public class POSMain {
 
     public static void main(String[] args) {
         Menu menu = new Menu();
-        for (MenuItem item : MenuInitializer.getAllMenuItems()) {
-            menu.addItem(item);
-        }
+        MenuStorage.loadMenuFromFile(menu, "menu.txt");
 
         System.out.println("=== Welcome to the CLI POS System ===");
 
@@ -42,6 +41,9 @@ public class POSMain {
             System.out.print("Create new order? (y/n): ");
             if (!scanner.nextLine().equalsIgnoreCase("y")) break;
         }
+
+        // Persist menu items on exit
+        MenuStorage.saveMenuToFile(menu, "menu.txt");
 
         System.out.println("Thank you for using the CLI POS System. Goodbye!");
     }

--- a/cli latest version/menu.txt
+++ b/cli latest version/menu.txt
@@ -1,0 +1,4 @@
+Chicken Burger Combo|880|With Fries & Pepsi|https://marrybrown.com/wp-content/uploads/2019/08/chicken-burger.png
+Hotouch Burger Combo|1110|With Fries & Pepsi|https://marrybrown.com/wp-content/uploads/2019/08/hotouch-burger.png
+Tower Burger Combo|1380|With Fries & Pepsi|https://marrybrown.com/wp-content/uploads/2019/08/Burger-Meal-Tower-Burger-Combo.png
+Nasi Marrybrown|990|Fried chicken and rice|http://marrybrown.com/wp-content/uploads/2019/08/Local-Delight-Nasi-Lemak.png


### PR DESCRIPTION
## Summary
- load menu data from `menu.txt` using new `MenuStorage` helper
- persist menu on exit
- include initial `menu.txt` data

## Testing
- `javac *.java` in `cli latest version`

------
https://chatgpt.com/codex/tasks/task_b_684bb3882220832da4f0a403a4c3afbf