### PR TITLE
Add CLI menu editor and integrity check

### DIFF
--- a/cli latest version/Menu.java
+++ b/cli latest version/Menu.java
@@ -6,5 +6,8 @@ import java.util.List;
 public class Menu {
     private List<MenuItem> items = new ArrayList<>();
     public void addItem(MenuItem item) { items.add(item); }
+    public void removeItem(int index) {
+        if (index >= 0 && index < items.size()) items.remove(index);
+    }
     public List<MenuItem> getItems() { return items; }
 }

--- a/cli latest version/MenuEditor.java
+++ b/cli latest version/MenuEditor.java
@@ -1,0 +1,63 @@
+import java.util.List;
+import java.util.Scanner;
+
+public class MenuEditor {
+    public static void editMenu(Menu menu, Scanner sc) {
+        while (true) {
+            System.out.println("\n--- MENU EDITOR ---");
+            List<MenuItem> items = menu.getItems();
+            for (int i = 0; i < items.size(); i++) {
+                MenuItem item = items.get(i);
+                System.out.printf("%d. %s - RM %.2f (%s)\n", i + 1, item.getName(), item.getPrice() / 100.0, item.getDescription());
+            }
+            System.out.println("a. Add item");
+            System.out.println("d. Delete item");
+            System.out.println("q. Quit editor");
+            System.out.print("Choice: ");
+            String choice = sc.nextLine();
+            if (choice.equalsIgnoreCase("q")) break;
+            if (choice.equalsIgnoreCase("a")) {
+                addItem(menu, sc);
+            } else if (choice.equalsIgnoreCase("d")) {
+                deleteItem(menu, sc);
+            }
+        }
+    }
+
+    private static void addItem(Menu menu, Scanner sc) {
+        System.out.print("Item name: ");
+        String name = sc.nextLine();
+        System.out.print("Price in cents: ");
+        int price;
+        try {
+            price = Integer.parseInt(sc.nextLine());
+        } catch (NumberFormatException e) {
+            System.out.println("Invalid price.");
+            return;
+        }
+        System.out.print("Description: ");
+        String desc = sc.nextLine();
+        System.out.print("Image URL: ");
+        String url = sc.nextLine();
+        MenuItem item = new MenuItem();
+        item.setName(name);
+        item.setPrice(price);
+        item.setDescription(desc);
+        item.setImagePath(url);
+        menu.addItem(item);
+        System.out.println("Item added.");
+    }
+
+    private static void deleteItem(Menu menu, Scanner sc) {
+        System.out.print("Enter item number to delete: ");
+        int index;
+        try {
+            index = Integer.parseInt(sc.nextLine()) - 1;
+        } catch (NumberFormatException e) {
+            System.out.println("Invalid input.");
+            return;
+        }
+        menu.removeItem(index);
+        System.out.println("Item removed if number was valid.");
+    }
+}

--- a/cli latest version/MenuStorage.java
+++ b/cli latest version/MenuStorage.java
@@ -1,0 +1,89 @@
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+
+public class MenuStorage {
+    private static String md5ForFile(Path path) throws IOException {
+        try {
+            MessageDigest md = MessageDigest.getInstance("MD5");
+            byte[] data = Files.readAllBytes(path);
+            byte[] digest = md.digest(data);
+            StringBuilder sb = new StringBuilder();
+            for (byte b : digest) sb.append(String.format("%02x", b));
+            return sb.toString();
+        } catch (NoSuchAlgorithmException e) {
+            return "";
+        }
+    }
+
+    public static void loadMenuFromFile(Menu menu, String filePath) {
+        Path path = Path.of(filePath);
+        Path hashPath = Path.of(filePath + ".md5");
+        if (!Files.exists(path) || !Files.exists(hashPath)) {
+            for (MenuItem item : MenuInitializer.getAllMenuItems()) {
+                menu.addItem(item);
+            }
+            saveMenuToFile(menu, filePath);
+            return;
+        }
+
+        try {
+            String expectedHash = Files.readString(hashPath).trim();
+            String actualHash = md5ForFile(path);
+            if (!actualHash.equals(expectedHash)) {
+                System.out.println("Menu checksum mismatch. Loading default items.");
+                for (MenuItem item : MenuInitializer.getAllMenuItems()) {
+                    menu.addItem(item);
+                }
+                saveMenuToFile(menu, filePath);
+                return;
+            }
+        } catch (IOException e) {
+            System.out.println("Error reading checksum: " + e.getMessage());
+        }
+
+        try (BufferedReader reader = Files.newBufferedReader(path)) {
+            String line;
+            while ((line = reader.readLine()) != null) {
+                String[] parts = line.split("\\|", -1);
+                if (parts.length < 4) continue;
+                MenuItem item = new MenuItem();
+                item.setName(parts[0]);
+                try {
+                    item.setPrice(Integer.parseInt(parts[1]));
+                } catch (NumberFormatException e) {
+                    item.setPrice(0);
+                }
+                item.setDescription(parts[2]);
+                item.setImagePath(parts[3]);
+                menu.addItem(item);
+            }
+        } catch (IOException e) {
+            System.out.println("Error loading menu: " + e.getMessage());
+        }
+    }
+
+    public static void saveMenuToFile(Menu menu, String filePath) {
+        Path path = Path.of(filePath);
+        Path hashPath = Path.of(filePath + ".md5");
+        try (BufferedWriter writer = Files.newBufferedWriter(path)) {
+            for (MenuItem item : menu.getItems()) {
+                writer.write(item.getName() + "|" + item.getPrice() + "|" + item.getDescription() + "|" + item.getImagePath());
+                writer.newLine();
+            }
+        } catch (IOException e) {
+            System.out.println("Error saving menu: " + e.getMessage());
+        }
+
+        try {
+            String hash = md5ForFile(path);
+            Files.writeString(hashPath, hash);
+        } catch (IOException e) {
+            System.out.println("Error writing checksum: " + e.getMessage());
+        }
+    }
+}

--- a/cli latest version/POSMain.java
+++ b/cli latest version/POSMain.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Scanner;
 
+
 public class POSMain {
     private static Scanner scanner = new Scanner(System.in);
     private static int orderIDCounter = 1001;
@@ -11,8 +12,17 @@ public class POSMain {
 
     public static void main(String[] args) {
         Menu menu = new Menu();
-        for (MenuItem item : MenuInitializer.getAllMenuItems()) {
-            menu.addItem(item);
+        MenuStorage.loadMenuFromFile(menu, "menu.txt");
+
+        System.out.print("Edit menu items? (y/n): ");
+        if (scanner.nextLine().equalsIgnoreCase("y")) {
+            System.out.print("Enter admin password: ");
+            if (admin.checkAuthentication(scanner.nextLine())) {
+                MenuEditor.editMenu(menu, scanner);
+                MenuStorage.saveMenuToFile(menu, "menu.txt");
+            } else {
+                System.out.println("Incorrect password.");
+            }
         }
 
         System.out.println("=== Welcome to the CLI POS System ===");
@@ -42,6 +52,9 @@ public class POSMain {
             System.out.print("Create new order? (y/n): ");
             if (!scanner.nextLine().equalsIgnoreCase("y")) break;
         }
+
+        // Persist menu items on exit
+        MenuStorage.saveMenuToFile(menu, "menu.txt");
 
         System.out.println("Thank you for using the CLI POS System. Goodbye!");
     }

--- a/cli latest version/menu.txt
+++ b/cli latest version/menu.txt
@@ -1,0 +1,4 @@
+Chicken Burger Combo|880|With Fries & Pepsi|https://marrybrown.com/wp-content/uploads/2019/08/chicken-burger.png
+Hotouch Burger Combo|1110|With Fries & Pepsi|https://marrybrown.com/wp-content/uploads/2019/08/hotouch-burger.png
+Tower Burger Combo|1380|With Fries & Pepsi|https://marrybrown.com/wp-content/uploads/2019/08/Burger-Meal-Tower-Burger-Combo.png
+Nasi Marrybrown|990|Fried chicken and rice|http://marrybrown.com/wp-content/uploads/2019/08/Local-Delight-Nasi-Lemak.png

--- a/cli latest version/menu.txt.md5
+++ b/cli latest version/menu.txt.md5
@@ -1,0 +1,1 @@
+b26a3df989f6f3b1fef866a026a2ff5e


### PR DESCRIPTION
## Summary
- add `MenuEditor` for adding/removing menu items via CLI
- store MD5 checksum with menu data and verify on load
- persist edited menu to text file with checksum

## Testing
- `javac *.java` in `cli latest version`


------
https://chatgpt.com/codex/tasks/task_b_684bb3882220832da4f0a403a4c3afbf